### PR TITLE
Fix: Conditionally render 'Browse' button in activities

### DIFF
--- a/js/generate-activity.js
+++ b/js/generate-activity.js
@@ -83,26 +83,21 @@ document.addEventListener('DOMContentLoaded', function() {
                 actDate.className = 'act-date';
                 actDate.textContent = "Date: " + item["act-date"];
 
-                const actFileButton = document.createElement('a');
-                const actFile = document.createElement('button');
-                actFile.className = 'act-file';
-                if (item["act-file"].length == 0) {
-                    actFileButton.setAttribute('href', 'javascript:void(0)');
-                } else {
-                    actFileButton.href = item["act-file"];
-                    actFile.textContent = 'Browse Taken Pictures';
-                    actFile.className = 'act-file';
-                    actFileButton.setAttribute('target', '_blank');
-                    actFileButton.appendChild(actFile);
-                }
-
-
-
                 swiperSlide.appendChild(pastImgCtnr);
                 swiperSlide.appendChild(actName);
                 swiperSlide.appendChild(actDate);
                 swiperSlide.appendChild(actDetails);
-                swiperSlide.appendChild(actFileButton);
+
+                if (item["act-file"].length !== 0) {
+                    const actFileButton = document.createElement('a');
+                    const actFile = document.createElement('button');
+                    actFile.className = 'act-file';
+                    actFileButton.href = item["act-file"];
+                    actFile.textContent = 'Browse Taken Pictures';
+                    actFileButton.setAttribute('target', '_blank');
+                    actFileButton.appendChild(actFile);
+                    swiperSlide.appendChild(actFileButton);
+                }
 
                 swiperWrapper.appendChild(swiperSlide);
             });


### PR DESCRIPTION
The "Browse Taken Pictures" button was being rendered for all activities, even those without an associated file link. This resulted in a non-functional button and a poor user experience.

This commit fixes the issue by conditionally rendering the button only when the 'act-file' field in the JSON data is not empty.